### PR TITLE
Move globals to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "eslint-plugin-ember": "^12.5.0",
     "eslint-plugin-n": "^17.15.1",
     "eslint-plugin-qunit": "^8.1.2",
+    "globals": "^15.14.0",
     "typescript-eslint": "^8.23.0"
   },
   "devDependencies": {
     "eslint": "^9.19.0",
-    "globals": "^15.14.0",
     "prettier": "^3.4.2"
   }
 }


### PR DESCRIPTION
When I removed globals from my app this was resolving to an old version installed by something else that breaks eslint, so this also needs to be a dependency instead of a devDep.