### PR TITLE
Remove `ember-addon` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "ember-addon",
     "ember",
     "eslint"
   ],


### PR DESCRIPTION
Causes ember-cli to try to `require` this as an addon when building. Which it can't do. 

This isn't really an addon either.

```
require() of ES Module /Users/liam/Work/ChronicleMap/chronicle/node_modules/.pnpm/ember-eslint@https+++codeload.github.com+NullVoxPopuli+ember-eslint+tar.gz+8a13e697f6cb346b26_xetpj4g6ytjmsxzss6ned37vxy/node_modules/ember-eslint/src/index.js from /Users/liam/Work/ChronicleMap/chronicle/node_modules/.pnpm/ember-cli@6.1.0_handlebars@4.7.8_underscore@1.13.7/node_modules/ember-cli/lib/models/package-info-cache/package-info.js not supported.
Instead change the require of index.js in /Users/liam/Work/ChronicleMap/chronicle/node_modules/.pnpm/ember-cli@6.1.0_handlebars@4.7.8_underscore@1.13.7/node_modules/ember-cli/lib/models/package-info-cache/package-info.js to a dynamic import() which is available in all CommonJS modules.
```